### PR TITLE
Don't overflow Unix seconds by using signed integers.

### DIFF
--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -438,20 +438,20 @@ func Test_Column_Date(t *testing.T) {
 
 func Test_Column_DateTime(t *testing.T) {
 	var (
-		buf     bytes.Buffer
-		timeNow = time.Now().Truncate(time.Second)
-		encoder = binary.NewEncoder(&buf)
-		decoder = binary.NewDecoder(&buf)
+		buf           bytes.Buffer
+		inTwentyYears = time.Now().Add(20 * 365 * 24 * time.Hour).Truncate(time.Second)
+		encoder       = binary.NewEncoder(&buf)
+		decoder       = binary.NewDecoder(&buf)
 	)
 	if column, err := columns.Factory("column_name", "DateTime", time.Local); assert.NoError(t, err) {
-		if err := column.Write(encoder, timeNow); assert.NoError(t, err) {
+		if err := column.Write(encoder, inTwentyYears); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
-				assert.Equal(t, timeNow, v)
+				assert.Equal(t, inTwentyYears, v)
 			}
 		}
-		if err := column.Write(encoder, timeNow.In(time.UTC).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
+		if err := column.Write(encoder, inTwentyYears.In(time.UTC).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
-				assert.Equal(t, timeNow, v)
+				assert.Equal(t, inTwentyYears, v)
 			}
 		}
 		if assert.Equal(t, "column_name", column.Name()) && assert.Equal(t, "DateTime", column.CHType()) {


### PR DESCRIPTION
On 19 January, 2038, Unix timestamp will overflow int32. Thus, reading `DateTime` values that are later than that breaks.

I stumbled across this  problem while reading a stored date of `2040-01-01 10:00:00 +0000 UTC` as  `1903-11-26 03:31:44 +0000 UTC`.

This PR parses DateTime using UInt32 decoders, thus supporting `DateTime` values from later than 19 January, 2038.